### PR TITLE
Fixing issue with parameter type hints and namespaces

### DIFF
--- a/tests/FunctionParser/IntegrationTest/FunctionParserTest.php
+++ b/tests/FunctionParser/IntegrationTest/FunctionParserTest.php
@@ -172,4 +172,15 @@ CODE;
         $parser = FunctionParser::fromCallable($doCrazyStringInterpolation);
         $this->assertEquals($code, $parser->getCode());
     }
+
+    public function testParseFunctionWithNamespaceTypeHintCorrectly()
+    {
+        $func = function (FunctionParser $parser1, $foo, Traversable $trav, array $array = array()) {};
+        $code = <<< 'CODE'
+function (\FunctionParser\FunctionParser $parser1, $foo, \Traversable $trav, array $array = array()) {}
+CODE;
+
+        $parser = FunctionParser::fromCallable($func);
+        $this->assertEquals($code, $parser->getCode());
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,4 +11,4 @@ if (!file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'composer.lock')) {
 require_once 'PHPUnit/TextUI/TestRunner.php';
 
 // Include the composer autoloader
-require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . '.composer' . DIRECTORY_SEPARATOR . 'autoload.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';


### PR DESCRIPTION
When using a closure like the following, the type hint should be rewritten to the fully qualified  class name.

``` php
use My\Dependency;

function (Dependency $dep) {
};
```
### Expected result:

``` php
use My\Dependency;

function (\My\Dependency $dep) {
};
```
### Actual result:

``` php
use My\Dependency;

function (Dependency $dep) {
};
```
