### PR TITLE
- fix in parseContext() - will handle properly variables with NULL value

### DIFF
--- a/src/FunctionParser.php
+++ b/src/FunctionParser.php
@@ -376,7 +376,7 @@ class FunctionParser
             // Construct the context by combining the variable names and values
             foreach ($variable_names as $variable_name)
             {
-                if (isset($variable_values[$variable_name]))
+                if (array_key_exists($variable_name, $variable_values))
                 {
                     $context[$variable_name] = $variable_values[$variable_name];
                 }


### PR DESCRIPTION
Fixes:
```php
$a = NULL;
$f = function() use ($a) {
}
```